### PR TITLE
fix: warn about prerelease

### DIFF
--- a/docs/promises/create-account.md
+++ b/docs/promises/create-account.md
@@ -16,6 +16,15 @@ Promise::new("subaccount.example.near".parse().unwrap())
     .transfer(250_000_000_000_000_000_000_000); // 2.5e23yN, 0.25N
 ```
 
+:::caution Prerelease!
+The `AccountId` behavior described throughout this document, including the `parse().unwrap()` on the argument passed to `Promise::new`, is a feature of `near-sdk-rs` **v4**. The functionality is [still possible](https://docs.rs/near-sdk/3.1.0/near_sdk/json_types/struct.ValidAccountId.html) using v3, but if you want to use the cleaner v4 syntax, use this in your `Cargo.toml`:
+
+```toml
+[dependencies]
+near-sdk = "4.0.0-pre2"
+```
+:::
+
 In the context of a full contract:
 
 ```rust

--- a/docs/promises/deploy-contract.md
+++ b/docs/promises/deploy-contract.md
@@ -22,6 +22,15 @@ Promise::new("subaccount.example.near".parse().unwrap())
     .deploy_contract(CODE.to_vec())
 ```
 
+:::caution Prerelease!
+The `AccountId` behavior described throughout this document, including the `parse().unwrap()` on the argument passed to `Promise::new`, is a feature of `near-sdk-rs` **v4**. The functionality is [still possible](https://docs.rs/near-sdk/3.1.0/near_sdk/json_types/struct.ValidAccountId.html) using v3, but if you want to use the cleaner v4 syntax, use this in your `Cargo.toml`:
+
+```toml
+[dependencies]
+near-sdk = "4.0.0-pre2"
+```
+:::
+
 Here's what a full contract might look like, showing a naïve way to pass `code` as an argument rather than hard-coding it with `include_bytes!`:
 
 ```rust

--- a/docs/promises/token-tx.md
+++ b/docs/promises/token-tx.md
@@ -21,6 +21,15 @@ let account_id: AccountId = "example.near".parse().unwrap();
 Promise::new(account_id).transfer(amount);
 ```
 
+:::caution Prerelease!
+The `AccountId` behavior described throughout this document is a feature of `near-sdk-rs` **v4**. The functionality is [still possible](https://docs.rs/near-sdk/3.1.0/near_sdk/json_types/struct.ValidAccountId.html) using v3, but if you want to use the cleaner v4 syntax, use this in your `Cargo.toml`:
+
+```toml
+[dependencies]
+near-sdk = "4.0.0-pre2"
+```
+:::
+
 In the context of a full contract and function call, this could look like:
 
 ```rust
@@ -50,3 +59,4 @@ Most of this is boilerplate you're probably familiar with by now – imports, s
 Using near-cli, someone could invoke this function with a call like:
 
     near call $CONTRACT pay '{"amount": "1000000000000000000000000", "to": "example.near"}'
+


### PR DESCRIPTION
This adds a caution block to each of the Promise pages that show `AccountId` behavior that only works with v4, telling people how to use the prerelease.