### PR TITLE
Fix reducing-contract-size/assertion conditional

### DIFF
--- a/docs/reducing-contract-size/examples.md
+++ b/docs/reducing-contract-size/examples.md
@@ -68,7 +68,7 @@ crate-type = ["cdylib"]
   :::caution Adds unnecessary bloat
 
   ```rust
-  assert_eq!(contract_owner, predecessor_account, "ERR_NOT_OWNER");
+  assert_ne!(contract_owner, predecessor_account, "ERR_NOT_OWNER");
   ```
   :::
 
@@ -77,7 +77,7 @@ crate-type = ["cdylib"]
   :::tip
 
   ```rust
-  if contract_owner == predecessor_account {
+  if contract_owner != predecessor_account {
     env::panic(b"ERR_NOT_OWNER");
   }
   ```


### PR DESCRIPTION
In the section

> [Example of a standard assertion](https://www.near-sdk.io/reducing-contract-size/examples#removing-rlib-from-the-manifest)


The example shows 
```rust
assert_eq!(contract_owner, predecessor_account, "ERR_NOT_OWNER");
```
and 
```rust
if contract_owner == predecessor_account {
  env::panic(b"ERR_NOT_OWNER");
}
```

The conditional above looks inverted while making the following assumptions:
- `contract_owner` is a state variable set when the contract was first deployed
- `predecessor_account` is the same as [`env::predecessor_account_id`](https://docs.rs/near-sdk/latest/near_sdk/env/fn.predecessor_account_id.html)

I haven't changed the `env::panic(b"ERR_NOT_OWNER");` to `env::panic_str("ERR_NOT_OWNER");` as the former hasn't been deprecated nor the later added on the stable version of the SDK (`3.1.0`).
Also, not sure what is the best/preferred approach: `env::panic(_str)` or [`require!()`](https://github.com/near/near-sdk-rs/blob/master/HELP.md#use-require-early).

_P.S: I'm fairly new to the the SDK so I might be wrong with my docs interpretation, in that case feel free to lmk and close this PR._