### PR TITLE
Update intro.md

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -45,6 +45,9 @@ cd my-project
 If you would like to generate a new crate manually with `cargo new --lib <crate-name>`, make sure you include the following configuration in the generated `Cargo.toml`:
 
 ```toml
+[dependencies]
+near-sdk = "3.1.0"
+
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
You MUST specify that the dependencies section be filled in with the near-sdk otherwise it simply won't build because all of the subsequent steps that use #[near_bindgen] and similar will not be available since the dependencies section is blank by default.