### PR TITLE
Updates to some links on reducing-contract-size

### DIFF
--- a/docs/reducing-contract-size/examples.md
+++ b/docs/reducing-contract-size/examples.md
@@ -60,7 +60,7 @@ crate-type = ["cdylib"]
 ```
 :::
 
-3. When using the Rust SDK, you may override the default JSON serialization to use [Borsh](https://borsh.io) instead. [See this page](/docs/contract-interface/serialization-interface.md#overriding-serialization-protocol-default) for more information and an example.
+3. When using the Rust SDK, you may override the default JSON serialization to use [Borsh](https://borsh.io) instead. [See this page](/contract-interface/serialization-interface#overriding-serialization-protocol-default) for more information and an example.
 4. When using assertions or guards, avoid using the standard `assert` macros like [`assert!`](https://doc.rust-lang.org/std/macro.assert.html), [`assert_eq!`](https://doc.rust-lang.org/std/macro.assert_eq.html), or [`assert_ne!`](https://doc.rust-lang.org/std/macro.assert_ne.html) as these may add bloat for information regarding the line number of the error. There are similar issues with `unwrap`, `expect`, and Rust's `panic!()` macro.
 
   Example of a standard assertion:

--- a/docs/reducing-contract-size/examples.md
+++ b/docs/reducing-contract-size/examples.md
@@ -60,7 +60,7 @@ crate-type = ["cdylib"]
 ```
 :::
 
-3. When using the Rust SDK, you may override the default JSON serialization to use [Borsh](https://borsh.io) instead. [See this page](/contract-interface/serialization-interface#overriding-serialization-protocol-default) for more information and an example.
+3. When using the Rust SDK, you may override the default JSON serialization to use [Borsh](https://borsh.io) instead. [See this page](/docs/contract-interface/serialization-interface.md#overriding-serialization-protocol-default) for more information and an example.
 4. When using assertions or guards, avoid using the standard `assert` macros like [`assert!`](https://doc.rust-lang.org/std/macro.assert.html), [`assert_eq!`](https://doc.rust-lang.org/std/macro.assert_eq.html), or [`assert_ne!`](https://doc.rust-lang.org/std/macro.assert_ne.html) as these may add bloat for information regarding the line number of the error. There are similar issues with `unwrap`, `expect`, and Rust's `panic!()` macro.
 
   Example of a standard assertion:
@@ -126,7 +126,6 @@ crate-type = ["cdylib"]
 
 For a `no_std` approach to minimal contracts, observe the following examples:
 
-- [Tiny contract](https://github.com/near/nearcore/tree/master/runtime/near-test-contracts/tiny-contract-rs)
 - [NEAR ETH Gateway](https://github.com/ilblackdragon/near-eth-gateway/blob/master/proxy/src/lib.rs)
 - [This YouTube video](https://youtu.be/Hy4VBSCqnsE) where Eugene demonstrates a fungible token in `no_std` mode. The code for this [example lives here](https://github.com/near/core-contracts/pull/88).
 - [Examples using a project called `nesdie`](https://github.com/austinabell/nesdie/tree/main/examples).


### PR DESCRIPTION
One link updated and can't find anywhere 'Tiny contract'