### PR TITLE
Add react option to intro.md

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -25,7 +25,7 @@ rustup target add wasm32-unknown-unknown
 
 ## Create a new project
 
-The best way to create a new NEAR app connected with a frontend is through [create-near-app](https://github.com/near/create-near-app). When initializing the project, be sure to include the `--contract=rust` flag to use the Rust SDK.
+The best way to create a new NEAR app connected with a frontend is through [create-near-app](https://github.com/near/create-near-app). When initializing the project, be sure to include the `--contract=rust` flag to use the Rust SDK. Add `--frontend=react` to use react. Default is vanilla HTML.
 
 ```bash
 npx create-near-app --contract=rust my-project


### PR DESCRIPTION
I was going through the near sdk docs and first fired create-near-app and was super confused why NEAR decided to make the front end in HTML instead of react, which is the defacto way of building front end for most people. It wasn't until later that I realized that there was a flag to make it use react (or vue or angular). I think that it should 100% say that on the page since a large percentage of people exclusively use react now.