### PR TITLE
fixed link to "private methods" doc

### DIFF
--- a/docs/contract-structure/near-bindgen.md
+++ b/docs/contract-structure/near-bindgen.md
@@ -84,7 +84,7 @@ pub fn my_method(&mut self) {
 
 ## Private Methods
 
-Some methods need to be exposed to allow the contract to call a method on itself through a promise, but want to disallow any other contract to call it. For this, use the `#[private]` annotation to panic when this method is called externally. See [private methods](../contract-interface/payable-methods.md) for more information.
+Some methods need to be exposed to allow the contract to call a method on itself through a promise, but want to disallow any other contract to call it. For this, use the `#[private]` annotation to panic when this method is called externally. See [private methods](../contract-interface/private-methods.md) for more information.
 
 This annotation can be applied to any method through the following:
 


### PR DESCRIPTION
This PR fixes the link to "private methods" doc on this page: https://www.near-sdk.io/contract-structure/near-bindgen#private-methods

(atm, if we click on the link, it leads us to the "payable methods" doc instead).