### PR TITLE
fixing the BIP-39 typo; also adding proof of where NEAR uses BIP-39

### DIFF
--- a/docs/zero-to-hero/03-intermediate/01-access-key-solution.md
+++ b/docs/zero-to-hero/03-intermediate/01-access-key-solution.md
@@ -42,7 +42,7 @@ It would be pretty long if we wrote it down, so it's often made human-readable w
 
 A seed phrase is a series of words (usually 12 or 24 words) that create a private key. (There's actually a [bit more to it](https://learnmeabitcoin.com/technical/mnemonic).)
 
-Seed phrases typically use a [BIP-30 wordlist](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md), but *they do not need to* use a wordlist or have a certain number of words. As long as the words create entropy, a crossword puzzle solution can act as a deterministic seed phrase.
+[Seed phrases typically use](https://github.com/near/near-seed-phrase/blob/d0f7671261edba57c6fcb2768994c533a635fc55/index.js#L9) a [BIP-39 wordlist](https://github.com/bitcoin/bips/blob/master/bip-0039/bip-0039-wordlists.md), but *they do not need to* use a wordlist or have a certain number of words. As long as the words create entropy, a crossword puzzle solution can act as a deterministic seed phrase.
 :::
 
 So when we add a new puzzle, we'll use the `AddKey` Action to add a limited, function-call access key can that *only* call the `submit_solution` method.


### PR DESCRIPTION
P.S. This chapter was cool. I didn't know this!

"There are no two words in [the BIP39 wordlist] with the same first 4 characters.

That means if you have the first 4 letters, you know the rest of the word by looking for those first 4 letters in the BIP39 wordlist. Some wallets will even fill in the rest of the word once the first 4 letters are entered."
...
This feature does not only apply to the English wordlist. It also applies to the Spanish, French, and Italian wordlists. 

https://www.blockplate.com/pages/first-4-letters-of-a-bip39-mnemonic-seed-phrase