### PR TITLE
Update intro.md

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -45,6 +45,9 @@ cd my-project
 If you would like to generate a new crate manually with `cargo new --lib <crate-name>`, make sure you include the following configuration in the generated `Cargo.toml`:
 
 ```toml
+[dependencies]
+near-sdk = "4.0.0"
+
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
add near-sdk into the dependencies in the example cargo.toml

This will allow you can copy/paste the example snippet from cargo.toml and start coding right away. In the next chapter of the SDK docs we are given an example  how to use collections already but it is never stated that we should include the SDK