### PR TITLE
Update workspaces to version 0.4.1

### DIFF
--- a/docs/testing/integration-tests.md
+++ b/docs/testing/integration-tests.md
@@ -55,7 +55,7 @@ near-sdk = { path = "../../near-sdk" }
 near-units = "0.2.0"
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.3.1"
+workspaces = "0.4.0"
 
 # remember to include a line for each contract
 fungible-token = { path = "./ft" }

--- a/docs/testing/integration-tests.md
+++ b/docs/testing/integration-tests.md
@@ -55,7 +55,7 @@ near-sdk = { path = "../../near-sdk" }
 near-units = "0.2.0"
 serde_json = "1.0"
 tokio = { version = "1.14", features = ["full"] }
-workspaces = "0.4.0"
+workspaces = "0.4.1"
 
 # remember to include a line for each contract
 fungible-token = { path = "./ft" }


### PR DESCRIPTION
Old workspaces 0.3.1 module doesn't work on Apple Silicon M1 you need to update it to latest version 0.4.0.